### PR TITLE
feat: add password reset flow to login page (Issue #16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Vue 3 frontend web application for AeroBook Flight Management System — a role-
 - **Password Reset** — Set password via secure email link for new members
 - **Dynamic Navigation** — Responsive sidebar/drawer that adapts to role permissions
 - **JWT Authentication** — Secure token-based auth with automatic renewal on page load
+- **Password Reset** — Request a reset link via email from the login page; secure set/reset flow
 - **HTTPS Support** — Works with a secured backend
 
 ## Tech Stack

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -45,6 +45,9 @@ export const authAPI = {
     new_password?: string;
   }) => api.put<{ message: string; user: User }>('/users/profile', data),
 
+  forgotPassword: (email: string) =>
+    api.post<{ message: string }>('/users/forgot-password', { email }),
+
   resetPassword: (token: string, password: string) =>
     api.post<{ message: string }>('/users/reset-password', { token, password })
 }

--- a/src/views/Login.test.ts
+++ b/src/views/Login.test.ts
@@ -9,12 +9,14 @@ vi.mock('vue-router', () => ({
 vi.mock('../services/api', () => ({
   authAPI: {
     login: vi.fn(),
-    getProfile: vi.fn()
+    getProfile: vi.fn(),
+    forgotPassword: vi.fn()
   }
 }))
 
 import Login from './Login.vue'
 import { useAuthStore } from '../stores/auth'
+import { authAPI } from '../services/api'
 
 function mountLogin() {
   return mount(Login, {
@@ -128,5 +130,65 @@ describe('Login.vue', () => {
 
     expect(wrapper.find('button[type="submit"]').text()).toContain('Sign In')
     expect(wrapper.find('button[type="submit"]').attributes('disabled')).toBeUndefined()
+  })
+
+  describe('Forgot Password flow', () => {
+    it('toggles between Login and Forgot Password modes', async () => {
+      const wrapper = mountLogin()
+      
+      expect(wrapper.find('input[type="password"]').exists()).toBe(true)
+      
+      await wrapper.find('.forgot-link').trigger('click')
+      expect(wrapper.find('input[type="password"]').exists()).toBe(false)
+      expect(wrapper.find('h1').text()).toContain('Welcome to AeroBook')
+      expect(wrapper.find('button[type="submit"]').text()).toContain('Send Reset Link')
+      
+      await wrapper.find('.back-link').trigger('click')
+      expect(wrapper.find('input[type="password"]').exists()).toBe(true)
+      expect(wrapper.find('button[type="submit"]').text()).toContain('Sign In')
+    })
+
+    it('calls authAPI.forgotPassword with entered email', async () => {
+      const wrapper = mountLogin()
+      ;(authAPI.forgotPassword as Mock).mockResolvedValue({ data: { message: 'sent' } })
+
+      await wrapper.find('.forgot-link').trigger('click')
+      await wrapper.find('#resetEmail').setValue('reset@example.com')
+      await wrapper.find('form').trigger('submit')
+      await flushPromises()
+
+      expect(authAPI.forgotPassword).toHaveBeenCalledWith('reset@example.com')
+      expect(wrapper.text()).toContain('Reset link sent')
+    })
+
+    it('shows error when email is not registered', async () => {
+      const wrapper = mountLogin()
+      ;(authAPI.forgotPassword as Mock).mockRejectedValue({
+        response: { status: 404, data: { message: 'User not found' } }
+      })
+
+      await wrapper.find('.forgot-link').trigger('click')
+      await wrapper.find('#resetEmail').setValue('nonexistent@example.com')
+      await wrapper.find('form').trigger('submit')
+      await flushPromises()
+
+      expect(wrapper.text()).toContain('This email is not registered in our system.')
+    })
+
+    it('shows loading state during forgot password request', async () => {
+      const wrapper = mountLogin()
+      let resolveRequest!: (value?: any) => void
+      ;(authAPI.forgotPassword as Mock).mockReturnValue(new Promise(r => { resolveRequest = r }))
+
+      await wrapper.find('.forgot-link').trigger('click')
+      await wrapper.find('#resetEmail').setValue('test@example.com')
+      await wrapper.find('form').trigger('submit')
+
+      expect(wrapper.find('button[type="submit"]').text()).toContain('Sending Link...')
+      expect(wrapper.find('button[type="submit"]').attributes('disabled')).toBeDefined()
+
+      resolveRequest({ data: {} })
+      await flushPromises()
+    })
   })
 })

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -9,7 +9,12 @@
         {{ errorMessage }}
       </div>
 
-      <form @submit.prevent="handleLogin">
+      <div v-if="successMessage" class="alert alert-success">
+        {{ successMessage }}
+      </div>
+
+      <!-- Login Form -->
+      <form v-if="!isForgotPassword" @submit.prevent="handleLogin">
         <div class="form-group">
           <label for="email">Email</label>
           <input
@@ -32,9 +37,36 @@
           />
         </div>
 
+        <div class="form-actions-link">
+          <a href="#" @click.prevent="isForgotPassword = true" class="forgot-link">Forgot Password?</a>
+        </div>
+
         <button type="submit" class="btn-primary" :disabled="isLoading">
           {{ isLoading ? 'Signing in...' : 'Sign In' }}
         </button>
+      </form>
+
+      <!-- Forgot Password Form -->
+      <form v-else @submit.prevent="handleForgotPassword">
+        <div class="form-group">
+          <label for="resetEmail">Email</label>
+          <input
+            v-model="email"
+            type="email"
+            id="resetEmail"
+            placeholder="your@email.com"
+            required
+          />
+          <p class="form-help">Enter your email to receive a reset link</p>
+        </div>
+
+        <button type="submit" class="btn-primary" :disabled="isLoading">
+          {{ isLoading ? 'Sending Link...' : 'Send Reset Link' }}
+        </button>
+
+        <div class="form-actions-link">
+          <a href="#" @click.prevent="isForgotPassword = false" class="back-link">Back to Sign In</a>
+        </div>
       </form>
     </div>
   </div>
@@ -43,13 +75,16 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useAuthStore } from '../stores/auth'
+import { authAPI } from '../services/api'
 
 const authStore = useAuthStore()
 
 const email = ref('')
 const password = ref('')
 const errorMessage = ref('')
+const successMessage = ref('')
 const isLoading = ref(false)
+const isForgotPassword = ref(false)
 
 async function handleLogin() {
   if (!email.value || !password.value) {
@@ -59,6 +94,7 @@ async function handleLogin() {
 
   isLoading.value = true
   errorMessage.value = ''
+  successMessage.value = ''
 
   try {
     await authStore.login(email.value, password.value)
@@ -69,6 +105,34 @@ async function handleLogin() {
       errorMessage.value = error.response.data?.message || 'Invalid email or password.'
     } else {
       errorMessage.value = error.response.data?.message || `Server error (${error.response.status}). Please try again.`
+    }
+  } finally {
+    isLoading.value = false
+  }
+}
+
+async function handleForgotPassword() {
+  if (!email.value) {
+    errorMessage.value = 'Please enter your email'
+    return
+  }
+
+  isLoading.value = true
+  errorMessage.value = ''
+  successMessage.value = ''
+
+  try {
+    await authAPI.forgotPassword(email.value)
+    successMessage.value = 'Reset link sent! Please check your email.'
+    // Keep email but clear it from form if you want? 
+    // Usually better to leave it so they know where it went.
+  } catch (error: any) {
+    if (!error.response) {
+      errorMessage.value = 'Unable to reach the server. Please try again later.'
+    } else if (error.response.status === 404) {
+      errorMessage.value = 'This email is not registered in our system.'
+    } else {
+      errorMessage.value = error.response.data?.message || 'Failed to send reset link. Please try again.'
     }
   } finally {
     isLoading.value = false
@@ -124,8 +188,42 @@ async function handleLogin() {
   margin-bottom: 2rem;
 }
 
+.form-help {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.5);
+  margin-top: 0.5rem;
+}
+
+.form-actions-link {
+  display: flex;
+  justify-content: center;
+  margin-top: 1rem;
+}
+
+.forgot-link, .back-link {
+  color: #93c5fd;
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: color 0.2s;
+}
+
+.forgot-link:hover, .back-link:hover {
+  color: #60a5fa;
+  text-decoration: underline;
+}
+
 button[type="submit"] {
   width: 100%;
   margin-top: 1rem;
+}
+
+.alert-success {
+  background: rgba(16, 185, 129, 0.1);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  color: #6ee7b7;
+  padding: 1rem;
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+  font-size: 0.9rem;
 }
 </style>


### PR DESCRIPTION
This PR implements the frontend UI on the login page for users to request password reset links, with togglable modes and integrated API calls.