### PR TITLE
chore: cleanup and revert temporary fixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,11 +46,7 @@ jobs:
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build Project Artifacts
-        run: |
-          # Load VITE_API_URL from .env.preview and export it for the build
-          export VITE_API_URL=$(grep VITE_API_URL .env.preview | cut -d '=' -f2)
-          echo "Building with VITE_API_URL=$VITE_API_URL"
-          vercel build --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy and Alias to Preview Domain
         run: |

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -10,7 +10,6 @@ import type {
 } from '../types'
 
 const API_URL = import.meta.env.VITE_API_URL || 'https://localhost:3000/api'
-console.log('[DEBUG] Frontend API_URL:', API_URL)
 
 const api = axios.create({
   baseURL: API_URL,


### PR DESCRIPTION
Now that the Vercel environment variables are correctly configured, this PR reverts the temporary workflow injections and removes the debug logs from both the frontend and backend.