### PR TITLE
fix: typescript build errors for reservation status

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,7 +33,7 @@ export interface Reservation {
   aircraft_id: number
   start_time: string
   end_time: string
-  status: 'scheduled' | 'completed' | 'cancelled'
+  status: 'scheduled' | 'in_progress' | 'completed' | 'cancelled'
   notes?: string
   created_at: string
   updated_at: string

--- a/src/views/Reservations.vue
+++ b/src/views/Reservations.vue
@@ -331,9 +331,10 @@ const editData = ref({
   aircraft_id: 0,
   start_time: '',
   end_time: '',
-  status: 'scheduled' as 'scheduled' | 'completed' | 'cancelled',
+  status: 'scheduled' as 'scheduled' | 'in_progress' | 'completed' | 'cancelled',
   notes: ''
 })
+
 
 // ── Calendar Constants ────────────────────────────────────
 const HOUR_HEIGHT = 60        // px per hour row


### PR DESCRIPTION
This PR adds the missing  status to the  interface and local view state, resolving the TS2322 and TS2367 errors that were blocking the build.