### PR TITLE
feat: show local timezone on reservations page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ Vue 3 frontend web application for AeroBook Flight Management System — a role-
 - **Smart Dashboard** — Personalized stats and recent activity. Members see their own upcoming reservations, while admins see club-wide data.
 - **Member Management** — Admin-only interface to manage members with optional welcome email suppression.
 - **Aircraft Fleet Management** — Comprehensive fleet tracking including tach hours and hourly rates.
-- **Reservation System** — Full-featured calendar (Day/Week/Month views) with mobile-optimized navigation.
+- **Reservation System** — Full-featured calendar (Day/Week/Month views) with mobile-optimized navigation, dynamic local timezone detection, and timezone indicators when booking or viewing reservations.
 - **UI Cleanup** — Technical database IDs removed from all user-facing views for a more professional experience.
 - **Security** — JWT Authentication with automatic session handling and secure HTTPS support.
 - **Password Reset** — Complete "Forgot Password" flow with 10-minute secure email links.
+- **"What's New" Modal** — Configurable pop-up modal with scheduling controls to present new features, updates, or announcements to users upon login.
 
 ## Tech Stack
 

--- a/public/whats-new.json
+++ b/public/whats-new.json
@@ -10,6 +10,11 @@
       "icon": "📊",
       "title": "Clickable Dashboard Stats",
       "description": "Quickly jump to relevant sections—like members, aircraft, reservations, or billing—by clicking directly on the dashboard status cards."
+    },
+    {
+      "icon": "🌐",
+      "title": "Local Timezone Support",
+      "description": "The reservation calendar, booking forms, and dashboards now automatically detect and display times in your local timezone."
     }
   ]
 }

--- a/src/utils/reservations.test.ts
+++ b/src/utils/reservations.test.ts
@@ -6,7 +6,11 @@ import {
   toDatetimeLocal,
   extractApiError,
   validateReservationTimes,
-  toUTCISOString
+  toUTCISOString,
+  formatDate,
+  formatTime,
+  getUserTimezone,
+  getUserTimezoneAbbr
 } from './reservations'
 
 describe('validateReservationTimes', () => {
@@ -186,5 +190,35 @@ describe('extractApiError', () => {
   it('returns empty string when no error or message in data', () => {
     const error = { response: { data: {} } }
     expect(extractApiError(error)).toBe('')
+  })
+})
+
+describe('timezone utilities', () => {
+  it('formatDate formats date including timezone abbreviation', () => {
+    const dateStr = '2027-06-13T09:00:00Z'
+    const result = formatDate(dateStr)
+    expect(result).toContain('Jun 13, 2027')
+    const parts = result.split(' ')
+    const tzPart = parts[parts.length - 1]
+    expect(tzPart.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('getUserTimezone returns a string with timezone and optional abbreviation', () => {
+    const tz = getUserTimezone()
+    expect(tz).toBeTruthy()
+    expect(typeof tz).toBe('string')
+  })
+
+  it('getUserTimezoneAbbr returns a string representation of the timezone abbreviation', () => {
+    const abbr = getUserTimezoneAbbr()
+    expect(typeof abbr).toBe('string')
+  })
+
+  it('formatTime formats time including timezone abbreviation', () => {
+    const dateStr = '2027-06-13T09:00:00Z'
+    const result = formatTime(dateStr)
+    const parts = result.split(' ')
+    const tzPart = parts[parts.length - 1]
+    expect(tzPart.length).toBeGreaterThanOrEqual(3)
   })
 })

--- a/src/utils/reservations.ts
+++ b/src/utils/reservations.ts
@@ -30,13 +30,27 @@ export function formatHour(hour: number): string {
 }
 
 export function formatTime(isoString: string): string {
-  return new Date(isoString).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+  return new Date(isoString).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZoneName: 'short' })
 }
 
 export function formatDate(isoString: string): string {
   return new Date(isoString).toLocaleString('en-US', {
-    month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit'
+    month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit', timeZoneName: 'short'
   })
+}
+
+export function getUserTimezone(): string {
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone
+  const abbr = Intl.DateTimeFormat('en-US', { timeZoneName: 'short' })
+    .formatToParts(new Date())
+    .find(part => part.type === 'timeZoneName')?.value
+  return abbr ? `${tz} (${abbr})` : tz
+}
+
+export function getUserTimezoneAbbr(): string {
+  return Intl.DateTimeFormat('en-US', { timeZoneName: 'short' })
+    .formatToParts(new Date())
+    .find(part => part.type === 'timeZoneName')?.value || ''
 }
 
 export function toDatetimeLocal(date: Date): string {

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -310,7 +310,8 @@ function formatDate(dateString: string) {
     month: 'short',
     day: 'numeric',
     hour: 'numeric',
-    minute: '2-digit'
+    minute: '2-digit',
+    timeZoneName: 'short'
   })
 }
 

--- a/src/views/Reservations.vue
+++ b/src/views/Reservations.vue
@@ -4,7 +4,7 @@
     <div class="page-header">
       <div>
         <h1>Reservations</h1>
-        <p>Manage aircraft bookings</p>
+        <p>Manage aircraft bookings <span class="timezone-indicator">({{ userTimezone }})</span></p>
       </div>
       <button class="btn-primary" @click="openNewReservationForm()">+ New Reservation</button>
     </div>
@@ -240,11 +240,11 @@
           </div>
           <div class="form-row">
             <div class="form-group">
-              <label>Start Time</label>
+              <label>Start Time ({{ userTimezoneAbbr }})</label>
               <input v-model="editData.start_time" type="datetime-local" :min="minDateTime" required />
             </div>
             <div class="form-group">
-              <label>End Time</label>
+              <label>End Time ({{ userTimezoneAbbr }})</label>
               <input v-model="editData.end_time" type="datetime-local" :min="minDateTime" required />
             </div>
           </div>
@@ -259,6 +259,9 @@
           <div class="form-group">
             <label>Notes</label>
             <textarea v-model="editData.notes" rows="3"></textarea>
+          </div>
+          <div class="form-group form-timezone-info">
+            <small>Times are selected and saved in your local timezone: <strong>{{ userTimezone }}</strong>.</small>
           </div>
           <div class="modal-actions">
             <button type="submit" class="btn-primary">Save Changes</button>
@@ -299,17 +302,20 @@
           </div>
           <div class="form-row">
             <div class="form-group">
-              <label>Start Time</label>
+              <label>Start Time ({{ userTimezoneAbbr }})</label>
               <input v-model="formData.start_time" type="datetime-local" :min="minDateTime" required />
             </div>
             <div class="form-group">
-              <label>End Time</label>
+              <label>End Time ({{ userTimezoneAbbr }})</label>
               <input v-model="formData.end_time" type="datetime-local" :min="minDateTime" required />
             </div>
           </div>
           <div class="form-group">
             <label>Notes</label>
             <textarea v-model="formData.notes" rows="3"></textarea>
+          </div>
+          <div class="form-group form-timezone-info">
+            <small>Times are selected and saved in your local timezone: <strong>{{ userTimezone }}</strong>.</small>
           </div>
           <div class="modal-actions">
             <button type="submit" class="btn-primary">Create Reservation</button>
@@ -328,13 +334,17 @@ import { reservationsAPI, membersAPI, aircraftAPI } from '../services/api'
 import type { Reservation, Member, Aircraft } from '../types'
 import {
   getWeekDays, sameDay, stripTime, formatHour, formatTime, formatDate,
-  toDatetimeLocal, extractApiError, validateReservationTimes, toUTCISOString
+  toDatetimeLocal, extractApiError, validateReservationTimes, toUTCISOString,
+  getUserTimezone, getUserTimezoneAbbr
 } from '../utils/reservations'
 import AppLayout from '../components/AppLayout.vue'
 
 type CalendarView = 'day' | 'week' | 'month' | 'my'
 
 const authStore = useAuthStore()
+
+const userTimezone = computed(() => getUserTimezone())
+const userTimezoneAbbr = computed(() => getUserTimezoneAbbr())
 
 // ── Data ──────────────────────────────────────────────────
 const reservations = ref<Reservation[]>([])
@@ -1396,5 +1406,19 @@ function formatDayColumnHeader(day: Date): string {
   background: rgba(34, 197, 94, 0.1);
   border: 1px solid rgba(34, 197, 94, 0.3);
   color: #86efac;
+}
+
+.timezone-indicator {
+  color: var(--sky-blue);
+  font-weight: 500;
+  font-size: 0.9rem;
+  margin-left: 0.5rem;
+}
+
+.form-timezone-info {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.6);
+  margin-top: -0.75rem;
+  margin-bottom: 1.5rem;
 }
 </style>


### PR DESCRIPTION
Closes #71. Adds local timezone detection and displays on the reservation calendar page, details view, and booking forms.