### PR TITLE
fix: add reminder_hours default to makeMember helper to resolve typecheck build error

### DIFF
--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -24,6 +24,7 @@ export function makeMember(overrides: Partial<Member> = {}): Member {
     email: 'member@example.com',
     role: 'member',
     is_active: true,
+    reminder_hours: 24,
     created_at: '2025-01-01T00:00:00Z',
     updated_at: '2025-01-01T00:00:00Z',
     ...overrides


### PR DESCRIPTION
Resolves a typescript compilation error where the `makeMember` helper was missing a value for `reminder_hours` (which is required by the `Member` interface).